### PR TITLE
Slackに送信するメッセージに動作環境の判定結果を添付したい

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,6 +25,7 @@ class App < Sinatra::Base
       token: ENV['SLACK_TOKEN'],
       channels: ENV['SLACK_CHANNEL'],
       filetype: 'javascript',
+      initial_comment: params[:message]
       content: JSON.pretty_generate(content)
     }
 

--- a/views/index.haml
+++ b/views/index.haml
@@ -18,8 +18,10 @@
 
   %form{action: '/', method: 'post'}
     %input{type: 'text', id: 'js-values-field', name: 'jsenv', value: '', hidden: true}
+    %input{type: 'text', id: 'message', name: 'message', value: '', hidden: true}
     %button{class: 'submitButton', type: 'submit', id: 'submit-button'}
       %i.fa.fa-fw.fa-paper-plane-o
       情報を送信する
 
+  %script{type: 'text/javascript', src: "https://system-requirements.smarthr.jp/envy.js"}
   %script{type: 'text/javascript', src: "javascript/main.js?t=#{Time.now.to_i}"}


### PR DESCRIPTION
## やりたいこと

サポート対応円滑化のため、ユーザーのUA情報を取得するだけでなくSmartHR動作環境との突合結果を添付したいです

## やったこと

新たに構築した外部スクリプト (※) を読み込むことで判定結果を `input[name=message]` に詰め込み、Slack APIへ送信するペイロードに含める方法をとっています

※ ブラウザの最新バージョンがいくつなのかをプロダクトのリリースフローとは切り離して逐一更新するために外部管理しています

## やっていないこと

ローカル環境でのテスト等はできておりません 😭 
