### PR TITLE
:+1: メッセージを改行に対応させたい

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -18,7 +18,7 @@
 
   %form{action: '/', method: 'post'}
     %input{type: 'text', id: 'js-values-field', name: 'jsenv', value: '', hidden: true}
-    %input{type: 'text', id: 'message', name: 'message', value: '', hidden: true}
+    %textarea{id: 'message', name: 'message', value: '', hidden: true}
     %button{class: 'submitButton', type: 'submit', id: 'submit-button'}
       %i.fa.fa-fw.fa-paper-plane-o
       情報を送信する


### PR DESCRIPTION
`input` だと改行ができないので `textarea` を用いることにしました (あわせて読み込むスクリプトの挙動も変えてあります)。

ローカル環境で動作確認済です！