### PR TITLE
利用していない環境変数 CUSTOM_RUBY_VERSION の設定を削除

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,10 +8,6 @@
   "website": "https://github.com/kufu/envy",
   "repository": "https://github.com/kufu/envy",
   "env": {
-    "CUSTOM_RUBY_VERSION": {
-      "description": "Ruby version",
-      "value": "2.4.1"
-    },
     "SLACK_TOKEN": {
       "description": "Slack legacy token: https://api.slack.com/custom-integrations/legacy-tokens",
       "value": ""


### PR DESCRIPTION
#52 により環境変数「CUSTOM_RUBY_VERSION」は参照されなくなりました。app.json の記述は不要なので削除しています。